### PR TITLE
Update openldap-rpm.rst

### DIFF
--- a/source/openldap-rpm.rst
+++ b/source/openldap-rpm.rst
@@ -64,12 +64,6 @@ To import this key:
 
     # rpm --import https://ltb-project.org/documentation/_static/RPM-GPG-KEY-LTB-project
 
-Then update:
-
-.. code-block:: console
-
-    # yum update
-
 Install packages
 ----------------
 


### PR DESCRIPTION
`yum update` is not the same as `apt update`, and is not needed after adding a new repo