### PR TITLE
Update sasl_delegation.rst

### DIFF
--- a/source/sasl_delegation.rst
+++ b/source/sasl_delegation.rst
@@ -103,7 +103,7 @@ To activate LDAP as SASL mechanism on Debian systems::
     DESC="SASL Authentication Daemon"
     NAME="saslauthd"
     MECHANISMS="ldap"
-    MECH_OPTIONS="-O /etc/saslauthd.conf"
+    MECH_OPTIONS="/etc/saslauthd.conf"
     THREADS=5
     OPTIONS="-r -c -m /var/run/saslauthd"
 


### PR DESCRIPTION
MECH_OPTIONS="-O /etc/saslauthd.conf"

ne fonctionne pas sur ubuntu

MECH_OPTIONS="/etc/saslauthd.conf"
fonctionne sur ubuntu

Je ne sais pas si c'est lié à ubuntu